### PR TITLE
Use IPv6 by default, add `useIPv6` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 declare namespace ipify {
 	interface Options {
 		/**
-		Use IPv6 API endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
+		Use the IPv6 API endpoint. The IPv6 endpoint will return an IPv6 address if available, IPv4 address otherwise.
+
+		Setting the `endpoint` option will override this.
 
 		@default true
 		*/
@@ -28,6 +30,7 @@ import ipify = require('ipify');
 (async () => {
 	console.log(await ipify());
 	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+
 	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace ipify {
 	interface Options {
 		/**
-		Use IPv6 api endpoint. Setting `endpoint` option will override this.
+		Use IPv6 api endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
 
 		@default true
 		*/
@@ -27,7 +27,7 @@ import ipify = require('ipify');
 
 (async () => {
 	console.log(await ipify());
-	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334' (if you have ipv6 address, same as next otherwise)
+	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
 	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,16 @@
 declare namespace ipify {
 	interface Options {
 		/**
+		Use IPv6 api endpoint. Setting `endpoint` option will override this.
+
+		@default true
+		*/
+		readonly useIPv6?: boolean;
+
+		/**
 		Custom API endpoint.
 
-		@default 'https://api.ipify.org'
+		@default 'https://api6.ipify.org'
 		*/
 		readonly endpoint?: string;
 	}
@@ -18,8 +25,10 @@ Get your public IP address.
 ```
 import ipify = require('ipify');
 
-(async => {
+(async () => {
 	console.log(await ipify());
+	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334' (if you have ipv6 address, same as next otherwise)
+	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace ipify {
 	interface Options {
 		/**
-		Use IPv6 api endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
+		Use IPv6 API endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 const got = require('got');
 
-module.exports = async options => {
-	options = {
-		endpoint: 'https://api.ipify.org',
-		...options
-	};
+const IPIFY_ENDPOINT_IPV4 = 'https://api.ipify.org';
+const IPIFY_ENDPOINT_IPV6 = 'https://api6.ipify.org';
 
-	const {body} = await got(options.endpoint);
+module.exports = async options => {
+	const useIPv6 = (options !== undefined && options.useIPv6 !== undefined) ? options.useIPv6 : true;
+	const endpoint = (options !== undefined && options.endpoint !== undefined) ? options.endpoint : (useIPv6 ? IPIFY_ENDPOINT_IPV6 : IPIFY_ENDPOINT_IPV4);
+	const {body} = await got(endpoint);
 	return body;
 };

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ const got = require('got');
 const IPIFY_ENDPOINT_IPV4 = 'https://api.ipify.org';
 const IPIFY_ENDPOINT_IPV6 = 'https://api6.ipify.org';
 
-module.exports = async options => {
-	const useIPv6 = (options !== undefined && options.useIPv6 !== undefined) ? options.useIPv6 : true;
-	const endpoint = (options !== undefined && options.endpoint !== undefined) ? options.endpoint : (useIPv6 ? IPIFY_ENDPOINT_IPV6 : IPIFY_ENDPOINT_IPV4);
+module.exports = async ({useIPv6 = true, endpoint} = {}) => {
+	if (endpoint === undefined) {
+		endpoint = useIPv6 ? IPIFY_ENDPOINT_IPV6 : IPIFY_ENDPOINT_IPV4;
+	}
+
 	const {body} = await got(endpoint);
 	return body;
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,4 +3,6 @@ import ipify = require('.');
 
 const options: ipify.Options = {};
 expectType<Promise<string>>(ipify());
+expectType<Promise<string>>(ipify({useIPv6: true}));
+expectType<Promise<string>>(ipify({useIPv6: false}));
 expectType<Promise<string>>(ipify({endpoint: 'https://example.com'}));

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ const ipify = require('ipify');
 
 (async () => {
 	console.log(await ipify());
-	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334' (if you have ipv6 address, same as next otherwise)
+	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
 	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();
@@ -41,7 +41,7 @@ Type: `object`
 Type: `boolean`<br>
 Default: `true`
 
-Use IPv6 api endpoint. Setting `endpoint` option will override this.
+Use IPv6 api endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
 
 ##### endpoint
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Type: `object`
 Type: `boolean`<br>
 Default: `true`
 
-Use IPv6 api endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
+Use IPv6 API endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
 
 ##### endpoint
 

--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,10 @@ $ npm install ipify
 ```js
 const ipify = require('ipify');
 
-(async => {
+(async () => {
 	console.log(await ipify());
+	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334' (if you have ipv6 address, same as next otherwise)
+	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();
 ```
@@ -34,10 +36,17 @@ Returns a `Promise<string>` with an IP address.
 
 Type: `object`
 
+##### useIPv6
+
+Type: `boolean`<br>
+Default: `true`
+
+Use IPv6 api endpoint. Setting `endpoint` option will override this.
+
 ##### endpoint
 
 Type: `string`<br>
-Default: `'https://api.ipify.org'`
+Default: `'https://api6.ipify.org'`
 
 Custom API endpoint.
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ const ipify = require('ipify');
 (async () => {
 	console.log(await ipify());
 	//=> '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+
 	console.log(await ipify({useIPv6: false});
 	//=> '82.142.31.236'
 })();
@@ -41,7 +42,9 @@ Type: `object`
 Type: `boolean`<br>
 Default: `true`
 
-Use IPv6 API endpoint. IPv6 endpoint will return IPv6 address if available, IPv4 address otherwise. Setting the `endpoint` option will override this.
+Use the IPv6 API endpoint. The IPv6 endpoint will return an IPv6 address if available, IPv4 address otherwise.
+
+Setting the `endpoint` option will override this.
 
 ##### endpoint
 

--- a/test.js
+++ b/test.js
@@ -4,5 +4,12 @@ import ipify from '.';
 
 test('main', async t => {
 	t.true(isIp(await ipify()));
-	t.true(isIp(await ipify({endpoint: 'https://api.ipify.org'})));
+});
+
+test('useIPv6:false', async t => {
+	t.true(isIp.v4(await ipify({useIPv6: false})));
+});
+
+test('endpoint:custom', async t => {
+	t.true(isIp.v4(await ipify({endpoint: 'https://api.ipify.org'})));
 });


### PR DESCRIPTION
- Use ipv6 endpoint by default
- Add useIPv6 option (re:endpoint, set it to just override the default + selected by useIPv6 option)
- Fixed usage samples (they were syntactically incorrect)

Fixes #11 

